### PR TITLE
fix: meet Apple HIG 44pt touch targets on mobile

### DIFF
--- a/app/blog/components/ui/CommentSection.tsx
+++ b/app/blog/components/ui/CommentSection.tsx
@@ -88,7 +88,7 @@ export default function CommentSection({ postId }: { postId: string }) {
               type="text"
               name="name"
               id="name"
-              className="block w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-zinc-950 dark:text-white dark:placeholder-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500"
+              className="block w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-zinc-950 dark:text-white dark:placeholder-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500 min-h-[44px]"
               placeholder="Name"
             />
           </div>
@@ -103,7 +103,7 @@ export default function CommentSection({ postId }: { postId: string }) {
               name="comment"
               id="comment"
               rows={2}
-              className="block w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-zinc-950 dark:text-white dark:placeholder-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500"
+              className="block w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-zinc-950 dark:text-white dark:placeholder-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500 min-h-[44px]"
               placeholder="Type a comment"
             />
           </div>
@@ -112,7 +112,7 @@ export default function CommentSection({ postId }: { postId: string }) {
               type="submit"
               className="group relative mb-2 me-2 inline-flex items-center justify-center overflow-hidden rounded-lg bg-gradient-to-br from-red-200 via-red-300 to-yellow-200 p-0.5 text-sm font-medium text-gray-900 focus:outline-none focus:ring-4 focus:ring-red-100 group-hover:from-red-200 group-hover:via-red-300 group-hover:to-yellow-200 dark:text-white dark:hover:text-gray-900 dark:focus:ring-red-400"
             >
-              <span className="relative rounded-md bg-white px-5 py-2.5 transition-all duration-75 ease-in group-hover:bg-opacity-0 dark:bg-zinc-950">
+              <span className="relative rounded-md bg-white px-5 py-2.5 transition-all duration-75 ease-in group-hover:bg-opacity-0 dark:bg-zinc-950 min-h-[44px] inline-flex items-center">
                 Post Comment
               </span>
             </button>

--- a/app/blog/components/ui/NewsletterSignupForm.tsx
+++ b/app/blog/components/ui/NewsletterSignupForm.tsx
@@ -91,11 +91,11 @@ export default function NewsletterSignupForm() {
               type="email"
               name={name}
               id="email"
-              className="block w-full rounded-md  px-4 py-1.5 text-primary border border-primary placeholder:text-tertiary focus:ring-inset focus:ring-indigo-600 bg-primary"
+              className="block w-full rounded-md  px-4 py-1.5 text-primary border border-primary placeholder:text-tertiary focus:ring-inset focus:ring-indigo-600 bg-primary min-h-[44px]"
               placeholder="you@example.com"
             />
           </div>
-          <button className="w-full whitespace-nowrap rounded-md bg-neutral-800 px-4 py-1.5 text-white hover:bg-neutral-900 focus:ring-inset focus:ring-indigo-600 focus-visible:outline focus-visible:outline-2 dark:bg-neutral-300 dark:text-black hover:dark:bg-neutral-100 md:w-fit ">
+          <button className="w-full whitespace-nowrap rounded-md bg-neutral-800 px-4 py-1.5 text-white hover:bg-neutral-900 focus:ring-inset focus:ring-indigo-600 focus-visible:outline focus-visible:outline-2 dark:bg-neutral-300 dark:text-black hover:dark:bg-neutral-100 md:w-fit min-h-[44px]">
             {"Sign up"}
           </button>
         </form>

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -50,7 +50,7 @@ export default function Navigation() {
           {({ open }: { open: boolean }) => (
             <>
               <Popover.Button
-                className="flex items-center gap-1 rounded-lg border-2 border-[#0a76a8] p-1.5 text-secondary focus:ring-0 focus-visible:outline-none"
+                className="flex items-center gap-1 rounded-lg border-2 border-[#0a76a8] p-1.5 text-secondary focus:ring-0 focus-visible:outline-none min-h-[44px] min-w-[44px]"
                 aria-expanded={open}
                 aria-label="Toggle menu"
               >
@@ -91,7 +91,7 @@ export default function Navigation() {
                         key={link.href}
                         href={link.href}
                         className={clsx(
-                          "rounded-md px-4 py-2 transition-colors hover:text-primary",
+                          "rounded-md px-4 py-2 transition-colors hover:text-primary min-h-[44px] flex items-center",
                           pathname === link.href
                             ? "bg-tertiary font-medium"
                             : "font-normal",

--- a/components/ui/NavLink.tsx
+++ b/components/ui/NavLink.tsx
@@ -15,7 +15,7 @@ export default function NavLink({ href, children }: NavLinkProps) {
   return (
     <Link
       className={clsx(
-        "px-4 py-2 rounded-lg text-sm hover:text-primary transition-colors",
+        "px-4 py-2 rounded-lg text-sm hover:text-primary transition-colors min-h-[44px] flex items-center",
         active ? "bg-secondaryA text-primary" : "text-secondary"
       )}
       href={href}


### PR DESCRIPTION
Part of #39 (P0 — Touch Targets)

**Changes:**
- `Navigation.tsx`: Added `min-h-[44px] min-w-[44px]` to mobile toggle button, `min-h-[44px]` to mobile nav links
- `NavLink.tsx`: Added `min-h-[44px]` to desktop nav links (affects landscape mobile)
- `NewsletterSignupForm.tsx`: Added `min-h-[44px]` to email input and submit button
- `CommentSection.tsx`: Added `min-h-[44px]` to name/comment inputs and submit button

All interactive elements now meet the recommended 44×44pt minimum touch target.