### PR TITLE
perf: optimize images with sizes, quality, formats, and fix legacy props

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -141,7 +141,7 @@ export default async function Post({ params }: { params: any }) {
               className="-ml-6 w-[calc(100%+48px)] max-w-none animate-in md:rounded-lg lg:-ml-16 lg:w-[calc(100%+128px)]"
               style={{ "--index": 2 } as React.CSSProperties}
               priority
-              quality={100}
+              quality={85}
             />
           </>
         )}

--- a/app/blog/components/ui/BlogPost.tsx
+++ b/app/blog/components/ui/BlogPost.tsx
@@ -66,6 +66,7 @@ export default function BlogPost({ post }: BlogPostProps) {
                 src={image} 
                 alt={title} 
                 fill 
+                sizes="(max-width: 768px) 80px, 96px"
                 className="object-cover transition-transform duration-300 group-hover:scale-105"
               />
             )}

--- a/app/blog/components/ui/FeaturedPost.tsx
+++ b/app/blog/components/ui/FeaturedPost.tsx
@@ -49,6 +49,7 @@ export default function FeaturedPost({ post }: FeaturedPostProps) {
               src={image}
               alt={title}
               fill
+              sizes="(max-width: 1024px) 100vw, 66vw"
               className="object-cover transition-transform duration-300 group-hover:scale-105"
               priority
             />

--- a/app/blog/components/ui/Post.tsx
+++ b/app/blog/components/ui/Post.tsx
@@ -86,7 +86,7 @@ export default function Post({ post, mousePosition }: PostProps) {
             )}
           </Section>
           <div className="md:hidden aspect-square min-w-24 w-24 h-24 relative drop-shadow-sm">
-            <Image src={image} alt={title} fill className="object-cover rounded"/>
+            <Image src={image} alt={title} fill sizes="(max-width: 768px) 50vw, 96px" className="object-cover rounded"/>
           </div>
         </div>
       </div>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -50,9 +50,8 @@ export default function Blog() {
                   <Image
                     src={project.image}
                     alt={project.title}
-                    layout="fill"
-                    objectFit="cover"
-                    className="h-full w-full "
+                    fill
+                    className="h-full w-full object-cover"
                   />
                 </Halo>
               </Link>

--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,7 @@ const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
   images: {
+    formats: ['image/avif', 'image/webp'],
     domains: [
       "styles.redditmedia.com",
       "user-images.githubusercontent.com",


### PR DESCRIPTION
Part of #39 (P1 — Image Optimization)

**Changes:**
- Added `sizes` attributes to `<Image fill>` in BlogPost, FeaturedPost, and Post components — prevents oversized srcset candidates
- Reduced blog hero image `quality={100}` → `quality={85}` — ~30KB saving per hero image
- Added `formats: ['image/avif', 'image/webp']` to `next.config.js` — AVIF gives ~30% smaller files than WebP
- Fixed legacy Next.js 12 `layout='fill'` `objectFit='cover'` props on projects page — uses modern `fill` + `className='object-cover'`