### PR TITLE
fix: viewport config, sticky nav on mobile, and layout polish

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -58,6 +58,8 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="preconnect" href="https://ik.imagekit.io" />
         <link
           rel="alternate"
           type="application/rss+xml"
@@ -85,7 +87,7 @@ export default function RootLayout({
             <Navigation />
             <div
               className={
-                "mx-auto max-w-[700px] px-6 pb-24 pt-16 md:px-6 md:pb-44 md:pt-20"
+                "mx-auto max-w-[700px] px-6 pb-24 pt-16 md:px-8 md:pb-44 md:pt-20"
               }
             >
               {children}

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -26,7 +26,7 @@ export default function Navigation() {
   const { theme } = useTheme();
 
   return (
-    <header className={clsx("relative top-0 z-20 bg-primary md:sticky")}>
+    <header className={clsx("sticky top-0 z-20 bg-primary")}>
       <nav
         className="lg mx-auto flex max-w-[700px] items-center justify-between gap-3 px-4 py-3 md:px-6"
         aria-label="Main navigation"
@@ -82,7 +82,7 @@ export default function Navigation() {
                 leaveTo="opacity-0 translate-y-1"
               >
                 <Popover.Panel
-                  className="absolute right-0 z-10 mt-2  w-40 origin-top-right overflow-auto rounded-xl border-2 border-[#0a76a8] bg-white p-2 text-base shadow-lg focus:outline-none dark:bg-black sm:text-sm"
+                  className="absolute right-0 z-10 mt-2  w-48 origin-top-right overflow-auto rounded-xl border-2 border-[#0a76a8] bg-white p-2 text-base shadow-lg focus:outline-none dark:bg-black sm:text-sm"
                   style={theme === "terminal" ? { background: "#040605" } : {}}
                 >
                   <div className="grid">


### PR DESCRIPTION
Part of #39 (P1 — No Explicit Viewport + P2 — Sticky Nav + Layout)

**Changes:**
- Added explicit `<meta name=\viewport\>` tag for accessibility (keyboard handling, zoom)
- Changed navigation from `md:sticky` to `sticky` — nav now sticks on mobile too
- Increased mobile nav panel from `w-40` (160px) to `w-48` (192px) — prevents text wrapping
- Increased desktop content padding from `px-6` to `px-8` for better readability
- Added `<link rel=\preconnect\ href=\https://ik.imagekit.io\>` — saves DNS lookup time